### PR TITLE
Add url_priority static

### DIFF
--- a/src/Admin/TaxonomyAdmin.php
+++ b/src/Admin/TaxonomyAdmin.php
@@ -17,4 +17,6 @@ class TaxonomyAdmin extends ModelAdmin
     private static $managed_models = [TaxonomyType::class];
 
     private static $menu_icon_class = 'font-icon-tags';
+    
+    private static $url_priority = 51;
 }


### PR DESCRIPTION
Setting the value fo $url_priority to hight than 50 (LeftAndMain) will ensure that this admin takes priority over the one silverstripe/taxonomy when CMS menu is created by get_cms_classes function in CMSMenu.